### PR TITLE
fixing behavior of transformers tokenizer for all chars and words

### DIFF
--- a/src/NERDA/preprocessing.py
+++ b/src/NERDA/preprocessing.py
@@ -63,8 +63,9 @@ class NERDADataSetReader():
             # bert tokenization
             wordpieces = self.transformer_tokenizer.tokenize(word)
             tokens.extend(wordpieces)
-            # make room for CLS
-            offsets.extend([1]+[0]*(len(wordpieces)-1))
+            # make room for CLS if there is an identified word piece
+            if len(wordpieces)>0:
+                offsets.extend([1]+[0]*(len(wordpieces)-1))
             # Extends the ner_tag if the word has been split by the wordpiece tokenizer
             target_tags.extend([tags[i]] * len(wordpieces)) 
         


### PR DESCRIPTION
Hi, I was finally able to work on the code over the weekend, and I found the cause of the error, which was due to a tokenizer problem.
In many languages, including my language (Persian), there are words and characters (abbreviations) that the `tokenize()` method in the `tokenizers` class is not able to identify, so in the face of such inputs, an empty list of word pieces is returned. In the next step, the `offsets` array will be expanded (by `[1]`) even if no word piece was identified, which eventually leads to errors in the training and evaluation process.
For example, the word ` ۖ` indicates sanctity for religious figures, which is seen in many writings but can not be identified.
