### PR TITLE
added version number to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,15 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+with open("src/NERDA/about.py") as f:
+    v = f.read()
+    for l in v.split("\n"):
+        if l.startswith("__version__"):
+            __version__ = l.split('"')[-2]
+
 setuptools.setup(
     name="NERDA", 
-    version="1.0.0",
+    version=__version__,
     author="Lars Kjeldgaard, Lukas Christian Nielsen",
     author_email="lars.kjeldgaard@eb.dk",
     description="A Framework for Finetuning Transformers for Named-Entity Recognition",

--- a/src/NERDA/__init__.py
+++ b/src/NERDA/__init__.py
@@ -1,1 +1,2 @@
 import NERDA
+from .about import __version__, __title__

--- a/src/NERDA/about.py
+++ b/src/NERDA/about.py
@@ -1,0 +1,2 @@
+__title__ = "NERDA"
+__version__ = "1.0.1"  # the ONLY source of version ID


### PR DESCRIPTION
Typically version numbers can be fetched from a package using `__version__`. This fix adds this feature to NERDA