### PR TITLE
Addapting preProcessing for some models of HF

### DIFF
--- a/src/NERDA/preprocessing.py
+++ b/src/NERDA/preprocessing.py
@@ -99,6 +99,10 @@ class NERDADataSetReader():
         # compute padding length
         if self.pad_sequences:
             padding_len = self.max_len - len(input_ids)
+             if self.pad_token_id == None:
+                input_ids = input_ids + ([0] * padding_len)
+            else:
+                input_ids = input_ids + ([self.pad_token_id] * padding_len)
             input_ids = input_ids + ([self.pad_token_id] * padding_len)
             masks = masks + ([0] * padding_len)  
             offsets = offsets + ([0] * padding_len)


### PR DESCRIPTION
Some models of HuggingFace, like 'pucpr/bioBERTpt-squad-v1.1-portuguese' uses 'None' as self.pad_token. It is a problem because return expects a vector of numbers and receives a vector with numbesr (for existing words) and None (for padding words). This if fix it.